### PR TITLE
Prevent error in which shim is not cleaned up

### DIFF
--- a/astra_camera/launch/astra_pro_plus.launch.xml
+++ b/astra_camera/launch/astra_pro_plus.launch.xml
@@ -57,6 +57,8 @@
     <arg name="oni_log_to_file" default="false"/>
     <arg name="enable_d2c_viewer" default="false"/>
     <arg name="enable_publish_extrinsic" default="false"/>
+
+    <node pkg="astra_camera" exec="clean_shm_node" />
     <group>
         <push-ros-namespace namespace="$(var camera_name)"/>
         <node name="camera" pkg="astra_camera" exec="astra_camera_node" output="screen">


### PR DESCRIPTION
Does what is says on the tin.
Still needs to be tested for abit.

It now will clean left over shims from the camera driver, which should have been clean-up, but for some reason are not.