### PR TITLE
Export astra_camera_node as a component as well

### DIFF
--- a/astra_camera/CMakeLists.txt
+++ b/astra_camera/CMakeLists.txt
@@ -166,9 +166,14 @@ target_link_libraries(${PROJECT_NAME}
   -L${ORBBEC_OPENNI2_REDIST}
   )
 
-add_executable(${PROJECT_NAME}_node
-  src/main.cpp
-  )
+rclcpp_components_register_node(${PROJECT_NAME}
+  PLUGIN "astra_camera::OBCameraNodeFactory"
+  EXECUTABLE ${PROJECT_NAME}_node
+)
+
+# add_executable(${PROJECT_NAME}_node
+#   src/main.cpp
+#   )
 
 target_include_directories(${PROJECT_NAME}_node PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
@@ -263,7 +268,7 @@ install(DIRECTORY openni2_redist/${HOST_PLATFORM}/OpenNI2
 
 install(TARGETS list_devices_node
   clean_shm_node
-  ${PROJECT_NAME}_node
+  # ${PROJECT_NAME}_node
   DESTINATION lib/${PROJECT_NAME}/
   )
 

--- a/astra_camera/include/astra_camera/ob_camera_node_factory.h
+++ b/astra_camera/include/astra_camera/ob_camera_node_factory.h
@@ -72,7 +72,3 @@ class OBCameraNodeFactory : public rclcpp::Node {
 };
 
 }  // namespace astra_camera
-
-#include <rclcpp_components/register_node_macro.hpp>
-
-RCLCPP_COMPONENTS_REGISTER_NODE(astra_camera::OBCameraNodeFactory)

--- a/astra_camera/src/ob_camera_node_factory.cpp
+++ b/astra_camera/src/ob_camera_node_factory.cpp
@@ -219,3 +219,6 @@ void OBCameraNodeFactory::checkConnectionTimer() {
 }
 
 }  // namespace astra_camera
+
+#include <rclcpp_components/register_node_macro.hpp>
+RCLCPP_COMPONENTS_REGISTER_NODE(astra_camera::OBCameraNodeFactory)


### PR DESCRIPTION
The `astra_camera_node` (actually `astra_camera::OBCameraNodeFactory`) was initially already setup to be exported as a component.
However, this wasn't done correctly, and it was not exported as such.

Note: `astra_camera/src/main.cpp` is now unused.
